### PR TITLE
Fix for last.fm scrobbling failure for me.

### DIFF
--- a/Classes/Scrobbler.m
+++ b/Classes/Scrobbler.m
@@ -139,7 +139,7 @@ Scrobbler *subscriber = nil;
 
     /* Try to get the saved session token, otherwise get a new one */
     NSString *str = KeychainGetPassword(LASTFM_KEYCHAIN_ITEM);
-    if (str == nil) {
+    if (str == nil || [@"" isEqual:str]) {
       NSLogd(@"No saved sesssion token for last.fm, fetching another");
       [self fetchAuthToken];
     } else {


### PR DESCRIPTION
The problem is that sometime the session key is blank in keychain.  This checks for that.
