### PR TITLE
Add ability to send a "Now Playing" message to last.fm

### DIFF
--- a/Classes/PlaybackController.h
+++ b/Classes/PlaybackController.h
@@ -1,6 +1,7 @@
 #import <Cocoa/Cocoa.h>
 #import "Station.h"
 #import "ImageLoader.h"
+#import "Scrobbler.h"
 
 @interface PlaybackController : NSObject {
   IBOutlet NSProgressIndicator *songLoadingProgress;
@@ -27,7 +28,7 @@
   NSTimer *progressUpdateTimer;
   ImageLoader *loader;
   Station *playing;
-  int scrobbleSent;
+  ScrobbleState scrobbleState;
   NSString *lastImgSrc;
 }
 

--- a/Classes/PlaybackController.m
+++ b/Classes/PlaybackController.m
@@ -273,13 +273,13 @@ BOOL playOnStart = YES;
 
   /* See http://www.last.fm/api/scrobbling#when-is-a-scrobble-a-scrobble for
      figuring out when a track should be scrobbled */
-  if (scrobbleSent == NewSong) {
-      scrobbleSent = NowPlaying;
-      [Scrobbler scrobble:[playing playing] status:scrobbleSent];
+  if (scrobbleState == NewSong) {
+      scrobbleState = NowPlaying;
+      [Scrobbler scrobble:[playing playing] state:NowPlaying];
   }
-  else if (dur > 30 && (prog * 2 > dur || prog > 4 * 60) && scrobbleSent == NowPlaying) {
-    scrobbleSent = FinalStatus;
-    [Scrobbler scrobble:[playing playing] status:FinalStatus];
+  else if (dur > 30 && (prog * 2 > dur || prog > 4 * 60) && scrobbleState == NowPlaying) {
+    scrobbleState = FinalStatus;
+    [Scrobbler scrobble:[playing playing] state:FinalStatus];
   }
 
 }
@@ -323,7 +323,7 @@ BOOL playOnStart = YES;
   [albumLabel setStringValue:[song album]];
   [playbackProgress setDoubleValue: 0];
   [progressLabel setStringValue: @"0:00/0:00"];
-  scrobbleSent = 0;
+  scrobbleState = NewSong;
 
   if ([[song rating] isEqualTo: @"1"]) {
     [like setEnabled:NO];

--- a/Classes/Scrobbler.h
+++ b/Classes/Scrobbler.h
@@ -15,14 +15,14 @@
   NSTimer *timer;
 }
 
-typedef enum status {
+typedef enum scrobblestate {
     NewSong,
     NowPlaying,
     FinalStatus
-} Status;
+} ScrobbleState;
 + (void) subscribe;
 + (void) unsubscribe;
-+ (void) scrobble: (Song*) song status: (Status) status;
++ (void) scrobble: (Song*) song state: (ScrobbleState) status;
 
 @property (retain) FMEngine *engine;
 @property (retain) NSString *authToken;
@@ -30,6 +30,6 @@ typedef enum status {
 
 - (void) fetchAuthToken;
 - (void) fetchSessionToken;
-- (void) scrobble: (Song*) song status: (Status) status;
+- (void) scrobble: (Song*) song state: (ScrobbleState) status;
 
 @end

--- a/Classes/Scrobbler.m
+++ b/Classes/Scrobbler.m
@@ -28,12 +28,12 @@ Scrobbler *subscriber = nil;
   subscriber = nil;
 }
 
-+ (void) scrobble:(Song *)song status:(Status)status {
++ (void) scrobble:(Song *)song state:(ScrobbleState)status {
   if (subscriber == nil) {
     return;
   }
 
-    [subscriber scrobble:song status:status];
+    [subscriber scrobble:song state:status];
 }
 
 - (void) error: (NSString*) message {
@@ -48,7 +48,7 @@ Scrobbler *subscriber = nil;
                       contextInfo:nil];
 }
 
-- (void) scrobble:(Song *)song status:(Status)status {
+- (void) scrobble:(Song *)song state:(ScrobbleState)status {
   /* If we don't have a sesion token yet, just ignore this for now */
   if (sessionToken == nil || [@"" isEqual:sessionToken]) {
     return;


### PR DESCRIPTION
This now sends 2 messages to Last.fm, the first when a song starts playing for the "Now Playing" stuff.  Then the standard message is sent as before.
