### PR TITLE
A better way of handling scrobbling for likes/dislikes

### DIFF
--- a/Classes/Pandora.m
+++ b/Classes/Pandora.m
@@ -273,7 +273,9 @@ static char *array_xpath = "/methodResponse/params/param/value/array/data/value"
   }
 
   PandoraCallback cb = ^(xmlDocPtr doc) {
-    [self notify:@"hermes.song-rated" with:nil];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [dict setObject:song forKey:@"song"];
+    [self notify:@"hermes.song-rated" with:dict];
   };
 
   return [self sendRequest:
@@ -305,7 +307,9 @@ static char *array_xpath = "/methodResponse/params/param/value/array/data/value"
   ];
 
   PandoraCallback cb = ^(xmlDocPtr doc) {
-    [self notify:@"hermes.song-tired" with:nil];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [dict setObject:song forKey:@"song"];
+    [self notify:@"hermes.song-tired" with:dict];
   };
 
   return [self sendRequest:

--- a/Classes/PlaybackController.m
+++ b/Classes/PlaybackController.m
@@ -169,10 +169,26 @@ BOOL playOnStart = YES;
 }
 
 - (void) songRated: (NSNotification*) not {
+  Song *song = [[not userInfo] objectForKey:@"song"];
+  if (song) {
+    [Scrobbler setPreference:song loved:[[song rating] isEqual:@"1"]];
+  }
   [self hideSpinner];
 }
 
 - (void) songTired: (NSNotification*) not {
+  /* I'm actually not sure if I should send this as a dislike..
+   * Could just mean "I've heard this 1000 times already!!!"
+   * I still think it's a good idea to send the song info for
+   * future utilization.
+   *
+  Song* song = [[not userInfo] objectForKey:@"song"];
+
+ 
+  if (song) {
+    [Scrobbler setPreference:song loved:NO];
+  }
+   */
   [self hideSpinner];
 }
 
@@ -424,7 +440,6 @@ BOOL playOnStart = YES;
   } else {
     NSLogd(@"Couldn't rate song?!");
   }
-  [Scrobbler setPreference:playingSong loved:YES];
 }
 
 /* Dislike button was hit */
@@ -444,7 +459,6 @@ BOOL playOnStart = YES;
   } else {
     NSLog(@"Couldn't rate song?!");
   }
-  [Scrobbler setPreference:playingSong loved:NO];
 }
 
 /* We are tired of the currently playing song, play another */

--- a/Classes/PreferencesController.h
+++ b/Classes/PreferencesController.h
@@ -6,6 +6,7 @@
 
 #define PLEASE_BIND_MEDIA     @"hermes.please-bind-media"
 #define PLEASE_SCROBBLE       @"hermes.please-scrobble"
+#define PLEASE_SCROBBLE_LIKES @"hermes.please-scrobble-likes"
 #define ONLY_SCROBBLE_LIKED   @"hermes.only-scrobble-liked"
 #define PLEASE_GROWL          @"hermes.please-growl"
 #define PLEASE_GROWL_NEW      @"hermes.please-growl-new"
@@ -14,6 +15,7 @@
 
 @interface PreferencesController : NSObject <NSWindowDelegate> {
   NSButton *scrobble;
+  NSButton *scrobbleLikes;
   NSButton *scrobbleOnlyLiked;
   NSButton *bindMedia;
   NSButton *growl;
@@ -22,6 +24,7 @@
 }
 
 @property (nonatomic, retain) IBOutlet NSButton *scrobble;
+@property (nonatomic, retain) IBOutlet NSButton *scrobbleLikes;
 @property (nonatomic, retain) IBOutlet NSButton *scrobbleOnlyLiked;
 @property (nonatomic, retain) IBOutlet NSButton *bindMedia;
 @property (nonatomic, retain) IBOutlet NSButton *growl;
@@ -29,6 +32,7 @@
 @property (nonatomic, retain) IBOutlet NSButton *growlNewSongs;
 
 - (IBAction) changeScrobbleTo: (id) sender;
+- (IBAction) changeScrobbleLikesTo: (id) sender;
 - (IBAction) changeScrobbleOnlyLikedTo: (id) sender;
 - (IBAction) changeBindMediaTo: (id) sender;
 - (IBAction) changeGrowlTo: (id) sender;

--- a/Classes/PreferencesController.m
+++ b/Classes/PreferencesController.m
@@ -5,8 +5,8 @@
 
 @implementation PreferencesController
 
-@synthesize bindMedia, scrobble, scrobbleOnlyLiked, growl, growlNewSongs,
-            growlPlayPause;
+@synthesize bindMedia, scrobble, scrobbleLikes, scrobbleOnlyLiked, growl,
+            growlNewSongs, growlPlayPause;
 
 - (void)windowDidBecomeMain:(NSNotification *)notification {
   NSInteger state;
@@ -14,6 +14,8 @@
 
   state = [defaults boolForKey:PLEASE_SCROBBLE] ? NSOnState : NSOffState;
   [scrobble setState:state];
+  state = [defaults boolForKey:PLEASE_SCROBBLE_LIKES] ? NSOnState : NSOffState;
+  [scrobbleLikes setState:state];
   state = [defaults boolForKey:ONLY_SCROBBLE_LIKED] ? NSOnState : NSOffState;
   [scrobbleOnlyLiked setState:state];
   state = [defaults boolForKey:PLEASE_BIND_MEDIA] ? NSOnState : NSOffState;
@@ -36,6 +38,13 @@
     [defaults setBool:NO forKey:PLEASE_SCROBBLE];
     [Scrobbler unsubscribe];
   }
+}
+
+- (IBAction) changeScrobbleLikesTo: (id) sender {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  
+  [defaults setBool:([scrobbleLikes state] == NSOnState)
+             forKey:PLEASE_SCROBBLE_LIKES];
 }
 
 - (IBAction) changeScrobbleOnlyLikedTo: (id) sender {

--- a/Classes/Scrobbler.m
+++ b/Classes/Scrobbler.m
@@ -96,10 +96,6 @@ static FMCallback errorChecker;
   Station *station = [notification object];
   Song *playing = [station playing];
   if (playing != nil) {
-    if ([[playing rating] isEqualToString:@"1"]) {
-      /* If a song is liked, then be sure we tell last.fm as such */
-      [subscriber setPreference:playing loved:YES];
-    }
     [subscriber scrobble:playing state:NewSong];
   }
 }
@@ -200,6 +196,11 @@ static FMCallback errorChecker;
 - (void) setPreference: (Song*)song loved:(BOOL)loved {
   /* If we don't have a sesion token yet, just ignore this for now */
   if (sessionToken == nil || [@"" isEqual:sessionToken] || song == nil) {
+    return;
+  }
+  
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  if (![defaults boolForKey:PLEASE_SCROBBLE_LIKES]) {
     return;
   }
 

--- a/Resources/English.lproj/MainMenu.xib
+++ b/Resources/English.lproj/MainMenu.xib
@@ -971,7 +971,6 @@
 					<int key="NSvFlags">256</int>
 					<string key="NSFrameSize">{240, 306}</string>
 					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView"/>
 					<bool key="NSViewIsLayerTreeHost">YES</bool>
 					<object class="NSDictionary" key="NSViewAnimations">
@@ -989,7 +988,7 @@
 					<int key="NSViewLayerContentsRedrawPolicy">2</int>
 					<bool key="NSViewCanDrawConcurrently">YES</bool>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<string key="NSFrameAutosaveName">Preferences</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
@@ -1007,7 +1006,6 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{21, 0}, {20, 20}}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="799869190"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="370691250">
@@ -1037,7 +1035,6 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrameSize">{20, 20}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="177435812"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="860695909">
@@ -1063,7 +1060,6 @@
 						<int key="NSvFlags">289</int>
 						<string key="NSFrame">{{262, 0}, {20, 20}}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="318563550"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="119645164">
@@ -1090,7 +1086,6 @@
 						<object class="NSPSMatrix" key="NSDrawMatrix"/>
 						<string key="NSFrame">{{238, 2}, {16, 16}}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="388599690"/>
 						<int key="NSpiFlags">20746</int>
 						<double key="NSMaxValue">100</double>
@@ -1100,7 +1095,6 @@
 						<int key="NSvFlags">289</int>
 						<string key="NSFrame">{{283, 0}, {20, 20}}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="861243305">
@@ -1136,7 +1130,6 @@
 										<int key="NSvFlags">274</int>
 										<string key="NSFrameSize">{301, 255}</string>
 										<reference key="NSSuperview" ref="922103838"/>
-										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="185912490"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTableHeaderView" key="NSHeaderView" id="109894432">
@@ -1144,14 +1137,15 @@
 											<int key="NSvFlags">256</int>
 											<string key="NSFrameSize">{301, 17}</string>
 											<reference key="NSSuperview" ref="541956757"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="922103838"/>
+											<reference key="NSNextKeyView" ref="770127997"/>
 											<reference key="NSTableView" ref="802382413"/>
 										</object>
-										<object class="_NSCornerView" key="NSCornerView">
-											<nil key="NSNextResponder"/>
+										<object class="_NSCornerView" key="NSCornerView" id="770127997">
+											<reference key="NSNextResponder" ref="895953141"/>
 											<int key="NSvFlags">-2147483392</int>
 											<string key="NSFrame">{{224, 0}, {16, 17}}</string>
+											<reference key="NSSuperview" ref="895953141"/>
+											<reference key="NSNextKeyView" ref="922103838"/>
 										</object>
 										<object class="NSMutableArray" key="NSTableColumns">
 											<bool key="EncodedWithXMLCoder">YES</bool>
@@ -1274,7 +1268,6 @@
 								</object>
 								<string key="NSFrame">{{1, 17}, {301, 255}}</string>
 								<reference key="NSSuperview" ref="895953141"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="802382413"/>
 								<reference key="NSDocView" ref="802382413"/>
 								<reference key="NSBGColor" ref="475079847"/>
@@ -1285,7 +1278,6 @@
 								<int key="NSvFlags">-2147483392</int>
 								<string key="NSFrame">{{224, 17}, {15, 102}}</string>
 								<reference key="NSSuperview" ref="895953141"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="441209787"/>
 								<reference key="NSTarget" ref="895953141"/>
 								<string key="NSAction">_doScroller:</string>
@@ -1297,7 +1289,6 @@
 								<int key="NSvFlags">-2147483392</int>
 								<string key="NSFrame">{{1, 156}, {121, 15}}</string>
 								<reference key="NSSuperview" ref="895953141"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="32600218"/>
 								<int key="NSsFlags">1</int>
 								<reference key="NSTarget" ref="895953141"/>
@@ -1313,28 +1304,27 @@
 								</object>
 								<string key="NSFrame">{{1, 0}, {301, 17}}</string>
 								<reference key="NSSuperview" ref="895953141"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="109894432"/>
 								<reference key="NSDocView" ref="109894432"/>
 								<reference key="NSBGColor" ref="475079847"/>
 								<int key="NScvFlags">4</int>
 							</object>
+							<reference ref="770127997"/>
 						</object>
 						<string key="NSFrame">{{0, 26}, {303, 273}}</string>
 						<reference key="NSSuperview" ref="889557454"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="541956757"/>
 						<int key="NSsFlags">133682</int>
 						<reference key="NSVScroller" ref="185912490"/>
 						<reference key="NSHScroller" ref="441209787"/>
 						<reference key="NSContentView" ref="922103838"/>
 						<reference key="NSHeaderClipView" ref="541956757"/>
+						<reference key="NSCornerView" ref="770127997"/>
 						<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
 					</object>
 				</object>
 				<string key="NSFrameSize">{303, 299}</string>
 				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="895953141"/>
 				<string key="NSClassName">NSView</string>
 			</object>
@@ -1368,7 +1358,6 @@
 							<int key="NSvFlags">266</int>
 							<string key="NSFrame">{{72, 260}, {191, 22}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="840379445"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="267093365">
@@ -1397,7 +1386,6 @@
 							<int key="NSvFlags">268</int>
 							<string key="NSFrame">{{17, 262}, {50, 17}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="119743964"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="549203628">
@@ -1420,7 +1408,6 @@
 							<int key="NSvFlags">265</int>
 							<string key="NSFrame">{{274, 254}, {96, 32}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="358398577"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="731513335">
@@ -1453,7 +1440,6 @@
 											<int key="NSvFlags">256</int>
 											<string key="NSFrameSize">{438, 185}</string>
 											<reference key="NSSuperview" ref="407281338"/>
-											<reference key="NSWindow"/>
 											<reference key="NSNextKeyView" ref="378584589"/>
 											<bool key="NSEnabled">YES</bool>
 											<object class="NSTableHeaderView" key="NSHeaderView" id="285414913">
@@ -1461,14 +1447,15 @@
 												<int key="NSvFlags">256</int>
 												<string key="NSFrameSize">{438, 17}</string>
 												<reference key="NSSuperview" ref="479122509"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="407281338"/>
+												<reference key="NSNextKeyView" ref="724667262"/>
 												<reference key="NSTableView" ref="162724941"/>
 											</object>
-											<object class="_NSCornerView" key="NSCornerView">
-												<nil key="NSNextResponder"/>
+											<object class="_NSCornerView" key="NSCornerView" id="724667262">
+												<reference key="NSNextResponder" ref="883990660"/>
 												<int key="NSvFlags">-2147483392</int>
 												<string key="NSFrame">{{424, 0}, {16, 17}}</string>
+												<reference key="NSSuperview" ref="883990660"/>
+												<reference key="NSNextKeyView" ref="407281338"/>
 											</object>
 											<object class="NSMutableArray" key="NSTableColumns">
 												<bool key="EncodedWithXMLCoder">YES</bool>
@@ -1519,7 +1506,6 @@
 									</object>
 									<string key="NSFrame">{{1, 17}, {438, 185}}</string>
 									<reference key="NSSuperview" ref="883990660"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="162724941"/>
 									<reference key="NSDocView" ref="162724941"/>
 									<reference key="NSBGColor" ref="475079847"/>
@@ -1530,7 +1516,6 @@
 									<int key="NSvFlags">-2147483392</int>
 									<string key="NSFrame">{{424, 17}, {15, 175}}</string>
 									<reference key="NSSuperview" ref="883990660"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="149700261"/>
 									<reference key="NSTarget" ref="883990660"/>
 									<string key="NSAction">_doScroller:</string>
@@ -1541,7 +1526,6 @@
 									<int key="NSvFlags">-2147483392</int>
 									<string key="NSFrame">{{-100, -100}, {438, 15}}</string>
 									<reference key="NSSuperview" ref="883990660"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="479122509"/>
 									<int key="NSsFlags">1</int>
 									<reference key="NSTarget" ref="883990660"/>
@@ -1557,22 +1541,22 @@
 									</object>
 									<string key="NSFrame">{{1, 0}, {438, 17}}</string>
 									<reference key="NSSuperview" ref="883990660"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="285414913"/>
 									<reference key="NSDocView" ref="285414913"/>
 									<reference key="NSBGColor" ref="475079847"/>
 									<int key="NScvFlags">4</int>
 								</object>
+								<reference ref="724667262"/>
 							</object>
 							<string key="NSFrame">{{20, 49}, {440, 203}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="580234420"/>
 							<int key="NSsFlags">133682</int>
 							<reference key="NSVScroller" ref="378584589"/>
 							<reference key="NSHScroller" ref="580234420"/>
 							<reference key="NSContentView" ref="407281338"/>
 							<reference key="NSHeaderClipView" ref="479122509"/>
+							<reference key="NSCornerView" ref="724667262"/>
 							<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
 						</object>
 						<object class="NSProgressIndicator" id="149700261">
@@ -1581,7 +1565,6 @@
 							<object class="NSPSMatrix" key="NSDrawMatrix"/>
 							<string key="NSFrame">{{20, 20}, {16, 16}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="494612315"/>
 							<int key="NSpiFlags">20746</int>
 							<double key="NSMaxValue">100</double>
@@ -1591,7 +1574,6 @@
 							<int key="NSvFlags">265</int>
 							<string key="NSFrame">{{370, 254}, {96, 32}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="883990660"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="453415571">
@@ -1613,7 +1595,6 @@
 							<int key="NSvFlags">289</int>
 							<string key="NSFrame">{{337, 12}, {129, 32}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="965310565">
@@ -1647,7 +1628,6 @@
 							</object>
 							<string key="NSFrame">{{312, 20}, {20, 20}}</string>
 							<reference key="NSSuperview" ref="931582578"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="110841313"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSImageCell" key="NSCell" id="479195428">
@@ -1667,10 +1647,9 @@
 					</object>
 					<string key="NSFrameSize">{480, 299}</string>
 					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="795644061"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
@@ -2076,13 +2055,37 @@
 												<int key="NSPeriodicInterval">25</int>
 											</object>
 										</object>
+										<object class="NSButton" id="342941814">
+											<reference key="NSNextResponder" ref="57098360"/>
+											<int key="NSvFlags">266</int>
+											<string key="NSFrame">{{73, 9}, {229, 18}}</string>
+											<reference key="NSSuperview" ref="57098360"/>
+											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView"/>
+											<bool key="NSEnabled">YES</bool>
+											<object class="NSButtonCell" key="NSCell" id="939856261">
+												<int key="NSCellFlags">-2080244224</int>
+												<int key="NSCellFlags2">0</int>
+												<string key="NSContents">Scrobble likes/dislikes to last.fm</string>
+												<reference key="NSSupport" ref="265285679"/>
+												<reference key="NSControlView" ref="342941814"/>
+												<int key="NSButtonFlags">1211912703</int>
+												<int key="NSButtonFlags2">2</int>
+												<reference key="NSNormalImage" ref="72008150"/>
+												<reference key="NSAlternateImage" ref="1057985179"/>
+												<string key="NSAlternateContents"/>
+												<string key="NSKeyEquivalent"/>
+												<int key="NSPeriodicDelay">200</int>
+												<int key="NSPeriodicInterval">25</int>
+											</object>
+										</object>
 										<object class="NSButton" id="144821986">
 											<reference key="NSNextResponder" ref="57098360"/>
 											<int key="NSvFlags">266</int>
 											<string key="NSFrame">{{94, 30}, {184, 18}}</string>
 											<reference key="NSSuperview" ref="57098360"/>
 											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView"/>
+											<reference key="NSNextKeyView" ref="342941814"/>
 											<bool key="NSEnabled">YES</bool>
 											<object class="NSButtonCell" key="NSCell" id="58956676">
 												<int key="NSCellFlags">-2080244224</int>
@@ -2137,7 +2140,7 @@
 					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="477244208"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
@@ -2163,7 +2166,7 @@
 				<string key="NSClassName">HistoryController</string>
 			</object>
 			<object class="NSView" id="803419858">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2172,7 +2175,6 @@
 						<int key="NSvFlags">266</int>
 						<string key="NSFrame">{{20, 167}, {179, 22}}</string>
 						<reference key="NSSuperview" ref="803419858"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="436156681"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="435966592">
@@ -2192,7 +2194,6 @@
 						<int key="NSvFlags">266</int>
 						<string key="NSFrame">{{20, 140}, {179, 22}}</string>
 						<reference key="NSSuperview" ref="803419858"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="852285455"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSSecureTextFieldCell" key="NSCell" id="957269991">
@@ -2216,8 +2217,6 @@
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{109, 104}, {96, 32}}</string>
 						<reference key="NSSuperview" ref="803419858"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="1019461690">
 							<int key="NSCellFlags">67239424</int>
@@ -2239,7 +2238,6 @@
 						<object class="NSPSMatrix" key="NSDrawMatrix"/>
 						<string key="NSFrame">{{23, 114}, {16, 16}}</string>
 						<reference key="NSSuperview" ref="803419858"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="610727975"/>
 						<int key="NSpiFlags">20746</int>
 						<double key="NSMaxValue">100</double>
@@ -2261,7 +2259,6 @@
 						</object>
 						<string key="NSFrame">{{81, 107}, {26, 30}}</string>
 						<reference key="NSSuperview" ref="803419858"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="767312450"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSImageCell" key="NSCell" id="470379801">
@@ -2277,12 +2274,10 @@
 					</object>
 				</object>
 				<string key="NSFrameSize">{219, 209}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="845232684"/>
 			</object>
 			<object class="NSCustomView" id="1025677791">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">274</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2292,22 +2287,18 @@
 						<object class="NSPSMatrix" key="NSDrawMatrix"/>
 						<string key="NSFrame">{{65, 59}, {32, 32}}</string>
 						<reference key="NSSuperview" ref="1025677791"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:3954</string>
 						<int key="NSpiFlags">20490</int>
 						<double key="NSMaxValue">100</double>
 					</object>
 				</object>
 				<string key="NSFrameSize">{163, 151}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="181078709"/>
 				<string key="NSReuseIdentifierKey">_NS:499</string>
 				<string key="NSClassName">NSView</string>
 			</object>
 			<object class="NSCustomView" id="448761198">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2316,8 +2307,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{93, 108}, {193, 17}}</string>
 						<reference key="NSSuperview" ref="448761198"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<int key="NSViewLayerContentsRedrawPolicy">2</int>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="530192397">
@@ -2332,8 +2321,6 @@
 					</object>
 				</object>
 				<string key="NSFrameSize">{378, 233}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="816862492"/>
 				<bool key="NSViewIsLayerTreeHost">YES</bool>
 				<int key="NSViewLayerContentsRedrawPolicy">2</int>
@@ -2702,7 +2689,7 @@
 				<bool key="NSViewCanDrawConcurrently">YES</bool>
 			</object>
 			<object class="NSCustomView" id="667579902">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2711,8 +2698,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{117, 179}, {88, 19}}</string>
 						<reference key="NSSuperview" ref="667579902"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:1534</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="413077063">
@@ -2735,7 +2720,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{86, 205}, {150, 96}}</string>
 						<reference key="NSSuperview" ref="667579902"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1055600725"/>
 						<int key="NSViewLayerContentsRedrawPolicy">2</int>
 						<bool key="NSEnabled">YES</bool>
@@ -2755,14 +2739,12 @@
 					</object>
 				</object>
 				<string key="NSFrameSize">{322, 378}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="856702945"/>
 				<string key="NSReuseIdentifierKey">_NS:499</string>
 				<string key="NSClassName">NSView</string>
 			</object>
 			<object class="NSCustomView" id="723088655">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2771,8 +2753,6 @@
 						<int key="NSvFlags">306</int>
 						<string key="NSFrame">{{17, 20}, {328, 174}}</string>
 						<reference key="NSSuperview" ref="723088655"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:3936</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="591689366">
@@ -2791,7 +2771,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{110, 261}, {142, 57}}</string>
 						<reference key="NSSuperview" ref="723088655"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="738874175"/>
 						<string key="NSReuseIdentifierKey">_NS:3936</string>
 						<bool key="NSEnabled">YES</bool>
@@ -2823,7 +2802,6 @@
 						</object>
 						<string key="NSFrame">{{170, 202}, {23, 27}}</string>
 						<reference key="NSSuperview" ref="723088655"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="150300031"/>
 						<int key="NSViewLayerContentsRedrawPolicy">2</int>
 						<bool key="NSEnabled">YES</bool>
@@ -2840,8 +2818,6 @@
 					</object>
 				</object>
 				<string key="NSFrameSize">{362, 431}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="52147311"/>
 				<string key="NSReuseIdentifierKey">_NS:499</string>
 				<string key="NSClassName">NSView</string>
@@ -2856,7 +2832,7 @@
 				<nil key="NSViewClass"/>
 				<nil key="NSUserInterfaceItemIdentifier"/>
 				<object class="NSView" key="NSWindowView" id="750108538">
-					<reference key="NSNextResponder"/>
+					<nil key="NSNextResponder"/>
 					<int key="NSvFlags">256</int>
 					<object class="NSMutableArray" key="NSSubviews">
 						<bool key="EncodedWithXMLCoder">YES</bool>
@@ -2865,8 +2841,6 @@
 							<int key="NSvFlags">265</int>
 							<string key="NSFrame">{{222, 201}, {75, 32}}</string>
 							<reference key="NSSuperview" ref="750108538"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
 							<string key="NSReuseIdentifierKey">_NS:161</string>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="674166687">
@@ -2899,8 +2873,7 @@
 											<int key="NSvFlags">274</int>
 											<string key="NSFrameSize">{283, 193}</string>
 											<reference key="NSSuperview" ref="524094810"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="414533000"/>
+											<reference key="NSNextKeyView" ref="597586230"/>
 											<string key="NSReuseIdentifierKey">_NS:3876</string>
 											<string key="NSMinGridSize">{0, 0}</string>
 											<string key="NSMaxGridSize">{0, 0}</string>
@@ -2916,7 +2889,6 @@
 									</object>
 									<string key="NSFrame">{{1, 1}, {283, 193}}</string>
 									<reference key="NSSuperview" ref="821539311"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="540774043"/>
 									<string key="NSReuseIdentifierKey">_NS:3874</string>
 									<reference key="NSDocView" ref="540774043"/>
@@ -2928,7 +2900,6 @@
 									<int key="NSvFlags">-2147483392</int>
 									<string key="NSFrame">{{-100, -100}, {15, 143}}</string>
 									<reference key="NSSuperview" ref="821539311"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="112184320"/>
 									<string key="NSReuseIdentifierKey">_NS:3881</string>
 									<reference key="NSTarget" ref="821539311"/>
@@ -2941,7 +2912,6 @@
 									<int key="NSvFlags">-2147483392</int>
 									<string key="NSFrame">{{-100, -100}, {233, 15}}</string>
 									<reference key="NSSuperview" ref="821539311"/>
-									<reference key="NSWindow"/>
 									<reference key="NSNextKeyView" ref="524094810"/>
 									<string key="NSReuseIdentifierKey">_NS:3883</string>
 									<int key="NSsFlags">1</int>
@@ -2952,8 +2922,7 @@
 							</object>
 							<string key="NSFrame">{{7, 8}, {285, 195}}</string>
 							<reference key="NSSuperview" ref="750108538"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="597586230"/>
+							<reference key="NSNextKeyView" ref="524094810"/>
 							<string key="NSReuseIdentifierKey">_NS:3872</string>
 							<int key="NSsFlags">133650</int>
 							<reference key="NSVScroller" ref="597586230"/>
@@ -2965,7 +2934,6 @@
 							<int key="NSvFlags">270</int>
 							<string key="NSFrame">{{10, 211}, {142, 17}}</string>
 							<reference key="NSSuperview" ref="750108538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="821539311"/>
 							<string key="NSReuseIdentifierKey">_NS:3936</string>
 							<bool key="NSEnabled">YES</bool>
@@ -2982,18 +2950,16 @@
 						</object>
 					</object>
 					<string key="NSFrameSize">{300, 240}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="609814486"/>
 					<string key="NSReuseIdentifierKey">_NS:2818</string>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
 			<object class="NSCollectionViewItem" id="596921285"/>
 			<object class="NSView" id="130168218">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">298</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -3002,7 +2968,6 @@
 						<int key="NSvFlags">266</int>
 						<string key="NSFrame">{{75, 35}, {182, 17}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="948311085"/>
 						<string key="NSReuseIdentifierKey">_NS:3936</string>
 						<bool key="NSEnabled">YES</bool>
@@ -3022,7 +2987,6 @@
 						<int key="NSvFlags">270</int>
 						<string key="NSFrame">{{75, 10}, {182, 17}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="23865754"/>
 						<string key="NSReuseIdentifierKey">_NS:3936</string>
 						<bool key="NSEnabled">YES</bool>
@@ -3042,7 +3006,6 @@
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{58, 34}, {20, 19}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="898470795"/>
 						<int key="NSViewLayerContentsRedrawPolicy">2</int>
 						<bool key="NSEnabled">YES</bool>
@@ -3066,7 +3029,6 @@
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{59, 10}, {18, 19}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="559295478"/>
 						<int key="NSViewLayerContentsRedrawPolicy">2</int>
 						<bool key="NSEnabled">YES</bool>
@@ -3090,7 +3052,6 @@
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{260, 33}, {20, 20}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="558596041"/>
 						<string key="NSReuseIdentifierKey">_NS:161</string>
 						<bool key="NSEnabled">YES</bool>
@@ -3115,7 +3076,6 @@
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{260, 7}, {20, 20}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="230695642"/>
 						<string key="NSReuseIdentifierKey">_NS:161</string>
 						<bool key="NSEnabled">YES</bool>
@@ -3140,8 +3100,6 @@
 						<int key="NSvFlags">32</int>
 						<string key="NSFrame">{{3, 0}, {278, 5}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:1459</string>
 						<string key="NSOffsets">{0, 0}</string>
 						<object class="NSTextFieldCell" key="NSTitleCell">
@@ -3165,7 +3123,6 @@
 						<int key="NSvFlags">268</int>
 						<string key="NSFrame">{{3, 4}, {50, 50}}</string>
 						<reference key="NSSuperview" ref="130168218"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="703913046"/>
 						<string key="NSReuseIdentifierKey">_NS:161</string>
 						<bool key="NSEnabled">YES</bool>
@@ -3190,8 +3147,6 @@
 					</object>
 				</object>
 				<string key="NSFrameSize">{285, 61}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="287341282"/>
 			</object>
 			<object class="NSArrayController" id="103900789">
@@ -4179,6 +4134,22 @@
 						<reference key="destination" ref="144821986"/>
 					</object>
 					<int key="connectionID">1588</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">changeScrobbleLikesTo:</string>
+						<reference key="source" ref="431381603"/>
+						<reference key="destination" ref="342941814"/>
+					</object>
+					<int key="connectionID">1607</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">scrobbleLikes</string>
+						<reference key="source" ref="431381603"/>
+						<reference key="destination" ref="342941814"/>
+					</object>
+					<int key="connectionID">1608</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -6019,6 +5990,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="543268637"/>
 							<reference ref="144821986"/>
+							<reference ref="342941814"/>
 						</object>
 						<reference key="parent" ref="850271217"/>
 					</object>
@@ -6087,6 +6059,20 @@
 						<int key="objectID">1585</int>
 						<reference key="object" ref="58956676"/>
 						<reference key="parent" ref="144821986"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1603</int>
+						<reference key="object" ref="342941814"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="939856261"/>
+						</object>
+						<reference key="parent" ref="503769364"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1604</int>
+						<reference key="object" ref="939856261"/>
+						<reference key="parent" ref="342941814"/>
 					</object>
 				</object>
 			</object>
@@ -6251,6 +6237,8 @@
 					<string>1579.IBPluginDependency</string>
 					<string>1584.IBPluginDependency</string>
 					<string>1585.IBPluginDependency</string>
+					<string>1603.IBPluginDependency</string>
+					<string>1604.IBPluginDependency</string>
 					<string>19.IBPluginDependency</string>
 					<string>197.IBPluginDependency</string>
 					<string>198.IBPluginDependency</string>
@@ -6644,6 +6632,8 @@
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>{{520, 444}, {240, 303}}</string>
 					<integer value="1"/>
 					<string>fromRight</string>
@@ -6754,7 +6744,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">1594</int>
+			<int key="maxID">1608</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -7392,11 +7382,13 @@
 							<string>changeGrowlNewSongTo:</string>
 							<string>changeGrowlPlayPauseTo:</string>
 							<string>changeGrowlTo:</string>
+							<string>changeScrobbleLikesTo:</string>
 							<string>changeScrobbleOnlyLikedTo:</string>
 							<string>changeScrobbleTo:</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
@@ -7413,6 +7405,7 @@
 							<string>changeGrowlNewSongTo:</string>
 							<string>changeGrowlPlayPauseTo:</string>
 							<string>changeGrowlTo:</string>
+							<string>changeScrobbleLikesTo:</string>
 							<string>changeScrobbleOnlyLikedTo:</string>
 							<string>changeScrobbleTo:</string>
 						</object>
@@ -7435,6 +7428,10 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
+								<string key="name">changeScrobbleLikesTo:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
 								<string key="name">changeScrobbleOnlyLikedTo:</string>
 								<string key="candidateClassName">id</string>
 							</object>
@@ -7453,10 +7450,12 @@
 							<string>growlNewSongs</string>
 							<string>growlPlayPause</string>
 							<string>scrobble</string>
+							<string>scrobbleLikes</string>
 							<string>scrobbleOnlyLiked</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSButton</string>
 							<string>NSButton</string>
 							<string>NSButton</string>
 							<string>NSButton</string>
@@ -7474,6 +7473,7 @@
 							<string>growlNewSongs</string>
 							<string>growlPlayPause</string>
 							<string>scrobble</string>
+							<string>scrobbleLikes</string>
 							<string>scrobbleOnlyLiked</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
@@ -7496,6 +7496,10 @@
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">scrobble</string>
+								<string key="candidateClassName">NSButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">scrobbleLikes</string>
 								<string key="candidateClassName">NSButton</string>
 							</object>
 							<object class="IBToOneOutletInfo">


### PR DESCRIPTION
1. Makes scrobbling likes/dislikes an option
2. Changing Likes/Dislikes from history window are now scrobbled
3. Uses `hermes.song-rated` NSNotification instead of calling `[Scrobbler setPrefrences]` from all possible places
4. Extended the `hermes.song-rated` and `hermes.song-tired` NSNotification to contain the song in the userInfo dictionary (since it may not be the currently playing song.)
