### PR TITLE
Tweak Makefile so that xctool can be used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,14 @@ CONFIGURATION = Debug
 HERMES        = ./build/$(CONFIGURATION)/Hermes.app/Contents/MacOS/Hermes
 DEBUGGER      = gdb
 
+# For some reason the project's SYMROOT setting is ignored when we specify an
+# explicit -project option. The -project option is required when using xctool.
+COMMON_OPTS    = -project Hermes.xcodeproj SYMROOT=build
+
 all: hermes
 
 hermes:
-	$(XCB) -configuration $(CONFIGURATION)
+	$(XCB) $(COMMON_OPTS) -configuration $(CONFIGURATION) -scheme Hermes
 
 run: hermes
 	$(HERMES)
@@ -15,8 +19,8 @@ dbg: hermes
 	$(DEBUGGER) $(HERMES)
 
 archive:
-	$(XCB) -configuration Release -target 'Build sparkle metadata'
+	$(XCB) $(COMMON_OPTS) -configuration Release -scheme 'Build sparkle metadata'
 
 clean:
-	$(XCB) clean
+	$(XCB) $(COMMON_OPTS) -scheme Hermes clean
 	rm -rf build


### PR DESCRIPTION
Caveats: `xcodebuild` seems to exhibit some odd behavior if you specify a -project option, which is required by xctool. `SYMROOT` and related settings get ignored. Manually setting `SYMROOT` when `xcodebuild` is invoked fixes where the built products are placed, but a lot of data is still put into `Derived Data` (and I'd rather not duplicate all those settings).
