### PR TITLE
Correct media keys not being re-enabled after disable.

### DIFF
--- a/Hermes.xcodeproj/project.pbxproj
+++ b/Hermes.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		44411DA7190166FB00EC4E05 /* PandoraDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 44411DA6190166FB00EC4E05 /* PandoraDevice.m */; };
 		44619493187407A300482DC4 /* HistoryCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 44619492187407A300482DC4 /* HistoryCollectionView.m */; };
 		44DFC8E018FDFCBC007422DC /* Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 44DFC8DF18FDFCBC007422DC /* Notifications.m */; };
+		843B578B19660680000898F2 /* NSObject+SPInvocationGrabbing.h in Headers */ = {isa = PBXBuildFile; fileRef = 843B578919660680000898F2 /* NSObject+SPInvocationGrabbing.h */; };
+		843B578C19660680000898F2 /* NSObject+SPInvocationGrabbing.m in Sources */ = {isa = PBXBuildFile; fileRef = 843B578A19660680000898F2 /* NSObject+SPInvocationGrabbing.m */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
@@ -187,6 +189,8 @@
 		44619492187407A300482DC4 /* HistoryCollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HistoryCollectionView.m; path = Controllers/HistoryCollectionView.m; sourceTree = "<group>"; };
 		44DFC8DE18FDFCBC007422DC /* Notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Notifications.h; sourceTree = "<group>"; };
 		44DFC8DF18FDFCBC007422DC /* Notifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Notifications.m; sourceTree = "<group>"; };
+		843B578919660680000898F2 /* NSObject+SPInvocationGrabbing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+SPInvocationGrabbing.h"; sourceTree = "<group>"; };
+		843B578A19660680000898F2 /* NSObject+SPInvocationGrabbing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+SPInvocationGrabbing.m"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Hermes-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Hermes-Info.plist"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Hermes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hermes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97177193159EAA7D00EE3355 /* cd.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cd.png; sourceTree = "<group>"; };
@@ -489,6 +493,8 @@
 		9728D887158C3D3100C078A4 /* SPMediaKeyTap */ = {
 			isa = PBXGroup;
 			children = (
+				843B578919660680000898F2 /* NSObject+SPInvocationGrabbing.h */,
+				843B578A19660680000898F2 /* NSObject+SPInvocationGrabbing.m */,
 				9728D898158C3DA500C078A4 /* SPMediaKeyTap.h */,
 				9728D899158C3DA500C078A4 /* SPMediaKeyTap.m */,
 			);
@@ -651,6 +657,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9728D89A158C3DA500C078A4 /* SPMediaKeyTap.h in Headers */,
+				843B578B19660680000898F2 /* NSObject+SPInvocationGrabbing.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -925,6 +932,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				843B578C19660680000898F2 /* NSObject+SPInvocationGrabbing.m in Sources */,
 				9728D89B158C3DA500C078A4 /* SPMediaKeyTap.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ImportedSources/SPMediaKeyTap/NSObject+SPInvocationGrabbing.h
+++ b/ImportedSources/SPMediaKeyTap/NSObject+SPInvocationGrabbing.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+@interface SPInvocationGrabber : NSObject {
+    id _object;
+    NSInvocation *_invocation;
+    int frameCount;
+    char **frameStrings;
+    BOOL backgroundAfterForward;
+    BOOL onMainAfterForward;
+    BOOL waitUntilDone;
+}
+-(id)initWithObject:(id)obj;
+-(id)initWithObject:(id)obj stacktraceSaving:(BOOL)saveStack;
+@property (readonly, retain, nonatomic) id object;
+@property (readonly, retain, nonatomic) NSInvocation *invocation;
+@property BOOL backgroundAfterForward;
+@property BOOL onMainAfterForward;
+@property BOOL waitUntilDone;
+-(void)invoke; // will release object and invocation
+-(void)printBacktrace;
+-(void)saveBacktrace;
+@end
+
+@interface NSObject (SPInvocationGrabbing)
+-(id)grab;
+-(id)invokeAfter:(NSTimeInterval)delta;
+-(id)nextRunloop;
+-(id)inBackground;
+-(id)onMainAsync:(BOOL)async;
+@end

--- a/ImportedSources/SPMediaKeyTap/NSObject+SPInvocationGrabbing.m
+++ b/ImportedSources/SPMediaKeyTap/NSObject+SPInvocationGrabbing.m
@@ -1,0 +1,127 @@
+#import "NSObject+SPInvocationGrabbing.h"
+#import <execinfo.h>
+
+#pragma mark Invocation grabbing
+@interface SPInvocationGrabber ()
+@property (readwrite, retain, nonatomic) id object;
+@property (readwrite, retain, nonatomic) NSInvocation *invocation;
+
+@end
+
+@implementation SPInvocationGrabber
+- (id)initWithObject:(id)obj;
+{
+	return [self initWithObject:obj stacktraceSaving:YES];
+}
+
+-(id)initWithObject:(id)obj stacktraceSaving:(BOOL)saveStack;
+{
+	self.object = obj;
+
+	if(saveStack)
+		[self saveBacktrace];
+
+	return self;
+}
+-(void)dealloc;
+{
+	free(frameStrings);
+	self.object = nil;
+	self.invocation = nil;
+	[super dealloc];
+}
+@synthesize invocation = _invocation, object = _object;
+
+@synthesize backgroundAfterForward, onMainAfterForward, waitUntilDone;
+- (void)runInBackground;
+{
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	@try {
+		[self invoke];
+	}
+	@finally {
+		[pool drain];
+	}
+}
+
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation {
+	[anInvocation retainArguments];
+	anInvocation.target = _object;
+	self.invocation = anInvocation;
+	
+	if(backgroundAfterForward)
+		[NSThread detachNewThreadSelector:@selector(runInBackground) toTarget:self withObject:nil];
+	else if(onMainAfterForward)
+        [self performSelectorOnMainThread:@selector(invoke) withObject:nil waitUntilDone:waitUntilDone];
+}
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)inSelector {
+	NSMethodSignature *signature = [super methodSignatureForSelector:inSelector];
+	if (signature == NULL)
+		signature = [_object methodSignatureForSelector:inSelector];
+    
+	return signature;
+}
+
+- (void)invoke;
+{
+
+	@try {
+		[_invocation invoke];
+	}
+	@catch (NSException * e) {
+		NSLog(@"SPInvocationGrabber's target raised %@:\n\t%@\nInvocation was originally scheduled at:", e.name, e);
+		[self printBacktrace];
+		printf("\n");
+		[e raise];
+	}
+
+	self.invocation = nil;
+	self.object = nil;
+}
+
+-(void)saveBacktrace;
+{
+  void *backtraceFrames[128];
+  frameCount = backtrace(&backtraceFrames[0], 128);
+  frameStrings = backtrace_symbols(&backtraceFrames[0], frameCount);
+}
+-(void)printBacktrace;
+{
+	for(int x = 3; x < frameCount; x++) {
+		if(frameStrings[x] == NULL) { break; }
+		printf("%s\n", frameStrings[x]);
+	}
+}
+@end
+
+@implementation NSObject (SPInvocationGrabbing)
+-(id)grab;
+{
+	return [[[SPInvocationGrabber alloc] initWithObject:self] autorelease];
+}
+-(id)invokeAfter:(NSTimeInterval)delta;
+{
+	id grabber = [self grab];
+	[NSTimer scheduledTimerWithTimeInterval:delta target:grabber selector:@selector(invoke) userInfo:nil repeats:NO];
+	return grabber;
+}
+- (id)nextRunloop;
+{
+	return [self invokeAfter:0];
+}
+-(id)inBackground;
+{
+    SPInvocationGrabber *grabber = [self grab];
+	grabber.backgroundAfterForward = YES;
+	return grabber;
+}
+-(id)onMainAsync:(BOOL)async;
+{
+    SPInvocationGrabber *grabber = [self grab];
+	grabber.onMainAfterForward = YES;
+    grabber.waitUntilDone = !async;
+	return grabber;
+}
+
+@end

--- a/ImportedSources/SPMediaKeyTap/SPMediaKeyTap.m
+++ b/ImportedSources/SPMediaKeyTap/SPMediaKeyTap.m
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Spotify AB
 #import "SPMediaKeyTap.h"
+#import "NSObject+SPInvocationGrabbing.h" // https://gist.github.com/511181, in submodule
 
 @interface SPMediaKeyTap ()
 -(BOOL)shouldInterceptMediaKeyEvents;
@@ -178,9 +179,10 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 		_shouldInterceptMediaKeyEvents = newSetting;
 	}
 	if(_tapThreadRL && oldSetting != newSetting) {
-		CFRunLoopPerformBlock(_tapThreadRL, kCFRunLoopCommonModes, ^{
-			[self pauseTapOnTapThread:newSetting];
-		});
+		id grab = [self grab];
+		[grab pauseTapOnTapThread:newSetting];
+		NSTimer *timer = [NSTimer timerWithTimeInterval:0 invocation:[grab invocation] repeats:NO];
+		CFRunLoopAddTimer(_tapThreadRL, (CFRunLoopTimerRef)timer, kCFRunLoopCommonModes);
 	}
 }
 


### PR DESCRIPTION
Updated SPMediaKeyTap to match what is in the main repo.

This update required the addition of two files.
Rational:  I had numerous cases where Hermes never regained the media keys.  I found a sure-fire way to reproduce this:
Launch Hermes and let it play.  Confirm the media keys work.
Launch QuickTime Player and play something.  Confirm the media keys are controlling QuickTime Player.
Quit QuickTime Player.
The media keys now launch iTunes.
Bring Hermes to the foreground
The media keys still launch iTunes.

With the changes in this pull request, when Hermes is brought to the foreground, it regains control through the media keys.
