### PR TITLE
HTTPS proxy fix

### DIFF
--- a/Sources/URLConnection.m
+++ b/Sources/URLConnection.m
@@ -176,6 +176,8 @@ static void URLConnectionStreamCallback(CFReadStreamRef aStream,
     [NSMutableDictionary dictionaryWithObjectsAndKeys:
       host, kCFStreamPropertyHTTPProxyHost,
       [NSNumber numberWithInt:port], kCFStreamPropertyHTTPProxyPort,
+      host, kCFStreamPropertyHTTPSProxyHost,
+      [NSNumber numberWithInt:port], kCFStreamPropertyHTTPSProxyPort,
       nil];
   CFReadStreamSetProperty(stream, kCFStreamPropertyHTTPProxy, proxySettings);
 }


### PR DESCRIPTION
In setHTTPProxy proxy function only kCFStreamPropertyHTTPProxyHost and kCFStreamPropertyHTTPProxyPort parameters are set, which do not have any effect on HTTPS connections. I have added kCFStreamPropertyHTTPSProxyHost and kCFStreamPropertyHTTPSProxyPort parameters with the same values and all seem to be OK now.
