### PR TITLE
[issue 224] fix history toolbar text unchaged to "station" when clicking.

### DIFF
--- a/Sources/HermesAppDelegate.m
+++ b/Sources/HermesAppDelegate.m
@@ -483,12 +483,14 @@
   [history showDrawer];
   [drawerToggle setImage:[NSImage imageNamed:@"radio"]];
   [drawerToggle setToolTip: @"Show station list"];
+  drawerToggle.paletteLabel = drawerToggle.label = @"Stations";
 }
 
 - (void) stationsShow {
   [stations showDrawer];
   [drawerToggle setImage:[NSImage imageNamed:@"history"]];
   [drawerToggle setToolTip: @"Show song history"];
+  drawerToggle.paletteLabel = drawerToggle.label = @"History";
 }
 
 - (IBAction) showHistoryDrawer:(id)sender {


### PR DESCRIPTION
just fix this issue [#224](https://github.com/HermesApp/Hermes/issues/224)