### PR TITLE
It appears that the response parser truncates at 1024 bytes on 10.11.3. It appears that if you do not read all the data within the callback, you will not be called again with the remaining data.

### DIFF
--- a/Sources/URLConnection.m
+++ b/Sources/URLConnection.m
@@ -13,7 +13,7 @@ static void URLConnectionStreamCallback(CFReadStreamRef aStream,
 
   switch (eventType) {
     case kCFStreamEventHasBytesAvailable:
-      if ((len = CFReadStreamRead(aStream, buf, sizeof(buf))) > 0) {
+      while ((len = CFReadStreamRead(aStream, buf, sizeof(buf))) > 0) {
         [conn->bytes appendBytes:buf length:len];
       }
       return;


### PR DESCRIPTION
This leads to repeated errors on login.