### PR TITLE
Add support for high quality 192k mp3 for Pandora One

### DIFF
--- a/Sources/Pandora/Pandora.m
+++ b/Sources/Pandora/Pandora.m
@@ -559,7 +559,7 @@ static NSString *hierrs[] = {
     created.year = 2000 + [dateCreated[@"year"] integerValue];
     created.month = 1 + [dateCreated[@"month"] integerValue];
     created.day = [dateCreated[@"date"] integerValue];
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     info[@"created"] = [gregorian dateFromComponents:created];
     NSString *art = result[@"artUrl"];
     if (art != nil) { info[@"art"] = art; }

--- a/Sources/Pandora/Pandora.m
+++ b/Sources/Pandora/Pandora.m
@@ -480,20 +480,32 @@ static NSString *hierrs[] = {
       [song setArtistUrl: s[@"artistDetailUrl"]];
       [song setTitleUrl: s[@"songDetailUrl"]];
       
+      id audioUrlMap = s[@"audioUrlMap"];
+      if ([audioUrlMap isKindOfClass:[NSDictionary class]]) {
+        if ([audioUrlMap[@"highQuality"] isKindOfClass:[NSDictionary class]])
+             [song setHighUrl:audioUrlMap[@"highQuality"][@"audioUrl"]];
+        if ([audioUrlMap[@"mediumQuality"] isKindOfClass:[NSDictionary class]])
+             [song setMedUrl:audioUrlMap[@"mediumQuality"][@"audioUrl"]];
+      }
+      
       id urls = s[@"additionalAudioUrl"];
       if ([urls isKindOfClass:[NSArray class]]) {
         NSArray *urlArray = urls;
         [song setLowUrl:urlArray[0]];
         if ([urlArray count] > 1) {
-          [song setMedUrl:urlArray[1]];
+          if (![song medUrl])
+            [song setMedUrl:urlArray[1]];
         } else {
-          [song setMedUrl:[song lowUrl]];
+          if (![song medUrl])
+            [song setMedUrl:[song lowUrl]];
           NSLog(@"bad medium format specified in request");
         }
         if ([urlArray count] > 2) {
-          [song setHighUrl:urlArray[2]];
+          if (![song highUrl])
+            [song setHighUrl:urlArray[2]];
         } else {
-          [song setHighUrl:[song medUrl]];
+          if (![song highUrl])
+            [song setHighUrl:[song medUrl]];
           NSLog(@"bad high format specified in request");
         }
       } else {
@@ -547,7 +559,7 @@ static NSString *hierrs[] = {
     created.year = 2000 + [dateCreated[@"year"] integerValue];
     created.month = 1 + [dateCreated[@"month"] integerValue];
     created.day = [dateCreated[@"date"] integerValue];
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     info[@"created"] = [gregorian dateFromComponents:created];
     NSString *art = result[@"artUrl"];
     if (art != nil) { info[@"art"] = art; }


### PR DESCRIPTION
In the response for station.getPlaylist the real high quality file is in a key called audioUrlMap like so:

`			"audioUrlMap": {
				"highQuality": {
					"bitrate": "192",
					"encoding": "mp3",
					"audioUrl": "...",
					"protocol": "http"
				},
				"mediumQuality": {
					"bitrate": "64",
					"encoding": "aacplus",
					"audioUrl": "...",
					"protocol": "http"
				}
			},`

The additionalAudioUrl list that the app currently uses only has files up to 128k.