### PR TITLE
Build with Xcode 7.3.1; fix NSURLRequest breakage and kCFStreamSSL* API removals

### DIFF
--- a/AudioStreamer/AudioStreamer.m
+++ b/AudioStreamer/AudioStreamer.m
@@ -648,9 +648,6 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
   if ([[url absoluteString] rangeOfString:@"https"].location == 0) {
     NSDictionary *sslSettings = @{
       (id)kCFStreamSSLLevel: (NSString*)kCFStreamSocketSecurityLevelNegotiatedSSL,
-      (id)kCFStreamSSLAllowsExpiredCertificates:  @NO,
-      (id)kCFStreamSSLAllowsExpiredRoots:         @NO,
-      (id)kCFStreamSSLAllowsAnyRoot:              @NO,
       (id)kCFStreamSSLValidatesCertificateChain:  @YES,
       (id)kCFStreamSSLPeerName:                   [NSNull null]
     };

--- a/Classes/FMEngine/FMEngine.m
+++ b/Classes/FMEngine/FMEngine.m
@@ -47,7 +47,7 @@ static NSInteger sortAlpha(NSString *n1, NSString *n2, void *context) {
 
   if(![httpMethod isEqualToString:@"POST"]) {
     NSURL *dataURL = [self generateURLFromDictionary:params];
-    request = [NSURLRequest requestWithURL:dataURL];
+    request = [NSMutableURLRequest requestWithURL:dataURL];
   } else {
     #ifdef _USE_JSON_
     request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:_LASTFM_BASEURL_ @"?format=json"]];

--- a/Classes/URLConnection.m
+++ b/Classes/URLConnection.m
@@ -84,9 +84,6 @@ static void URLConnectionStreamCallback(CFReadStreamRef aStream,
   if ([urlstring rangeOfString:@"https"].location == 0) {
     NSDictionary *settings =
     @{(id)kCFStreamSSLLevel: (NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL,
-     (id)kCFStreamSSLAllowsExpiredCertificates: @NO,
-     (id)kCFStreamSSLAllowsExpiredRoots: @NO,
-     (id)kCFStreamSSLAllowsAnyRoot: @NO,
      (id)kCFStreamSSLValidatesCertificateChain: @YES,
      (id)kCFStreamSSLPeerName: [NSNull null]};
 


### PR DESCRIPTION
These small changes allow me to compile Hermes in Xcode 7.3.1, on El Capitan. Thanks!