### PR TITLE
Fix audio always passing through proxy.

### DIFF
--- a/Sources/Pandora/Station.m
+++ b/Sources/Pandora/Station.m
@@ -161,7 +161,7 @@
   [stream setBufferInfinite:TRUE];
   [stream setTimeoutInterval:15];
 
-  if (PREF_KEY_VALUE(PROXY_AUDIO)) {
+  if (PREF_KEY_BOOL(PROXY_AUDIO)) {
     switch ([PREF_KEY_VALUE(ENABLED_PROXY) intValue]) {
       case PROXY_HTTP:
         [stream setHTTPProxy:PREF_KEY_VALUE(PROXY_HTTP_HOST)


### PR DESCRIPTION
PREF_KEY_VALUE(PROXY_AUDIO) was always true as it checks if the option PROXY_AUDIO exists not if it is true.