### PR TITLE
Simple solution to post notification on termination

### DIFF
--- a/Hermes.xcodeproj/project.pbxproj
+++ b/Hermes.xcodeproj/project.pbxproj
@@ -587,6 +587,12 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 0800;
+				TargetAttributes = {
+					8D1107260486CEB800E47090 = {
+						DevelopmentTeam = UCYPTT5Q5W;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Hermes" */;
 			compatibilityVersion = "Xcode 6.3";
@@ -759,8 +765,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = UCYPTT5Q5W;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
@@ -790,9 +797,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = UCYPTT5Q5W;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",

--- a/Sources/Controllers/PlaybackController.h
+++ b/Sources/Controllers/PlaybackController.h
@@ -57,6 +57,7 @@
 
 - (BOOL) play;
 - (BOOL) pause;
+- (void) stop;
 - (void) setIntegerVolume: (NSInteger) volume;
 - (NSInteger) integerVolume;
 - (void) pauseOnScreensaverStart: (NSNotification *) aNotification;

--- a/Sources/Controllers/PlaybackController.m
+++ b/Sources/Controllers/PlaybackController.m
@@ -435,6 +435,10 @@ BOOL playOnStart = YES;
   }
 }
 
+- (void) stop {
+  [playing stop];
+}
+
 - (void) rate:(Song *)song as:(BOOL)liked {
   if (!song || [[song station] shared]) return;
   int rating = liked ? 1 : -1;

--- a/Sources/HermesAppDelegate.m
+++ b/Sources/HermesAppDelegate.m
@@ -272,6 +272,7 @@
 
 - (void) applicationWillTerminate: (NSNotification *)aNotification {
   [playback saveState];
+  [playback stop]; 
   [history saveSongs];
 }
 


### PR DESCRIPTION
Stops the stream on application termination/quit. This has the effect of posting a notification to both Growl & OS X that there has been a state change. This helps developers who are developing against Hermes, like me, to know if there is an application/play state change. If this isn't the best way to provide this notification, then I would love to work with someone to make such a notification occur when Hermes quits.