### PR TITLE
Simple solution to post notification on quit

### DIFF
--- a/Sources/Controllers/PlaybackController.h
+++ b/Sources/Controllers/PlaybackController.h
@@ -57,6 +57,7 @@
 
 - (BOOL) play;
 - (BOOL) pause;
+- (void) stop;
 - (void) setIntegerVolume: (NSInteger) volume;
 - (NSInteger) integerVolume;
 - (void) pauseOnScreensaverStart: (NSNotification *) aNotification;

--- a/Sources/Controllers/PlaybackController.m
+++ b/Sources/Controllers/PlaybackController.m
@@ -435,6 +435,10 @@ BOOL playOnStart = YES;
   }
 }
 
+- (void) stop {
+  [playing stop];
+}
+
 - (void) rate:(Song *)song as:(BOOL)liked {
   if (!song || [[song station] shared]) return;
   int rating = liked ? 1 : -1;

--- a/Sources/HermesAppDelegate.m
+++ b/Sources/HermesAppDelegate.m
@@ -272,6 +272,7 @@
 
 - (void) applicationWillTerminate: (NSNotification *)aNotification {
   [playback saveState];
+  [playback stop];
   [history saveSongs];
 }
 


### PR DESCRIPTION
Stops the stream on application termination/quit. This has the effect of posting a notification to both Growl & OS X that there has been a state change. This helps developers who are developing against Hermes, like me, to know if there is an application/play state change. If this isn't the best way to provide this notification, then I would love to work with someone to make such a notification occur when Hermes quits.