### PR TITLE
Fixes the Hermes' dock icon resolution

### DIFF
--- a/Sources/HermesAppDelegate.m
+++ b/Sources/HermesAppDelegate.m
@@ -570,11 +570,13 @@
 }
 
 - (IBAction) updateDockIcon:(id)sender {
+  NSSize size = {.width = 1024, .height = 1024};
   if (PREF_KEY_BOOL(DOCK_ICON_ALBUM_ART)) {
-    NSSize size = {.width = 1024, .height = 1024};
     [NSApp setApplicationIconImage:[self buildPlayPauseAlbumArtImage:size]];
   } else {
-    [NSApp setApplicationIconImage:[NSImage imageNamed:@"pandora"]];
+    NSImage *icon = [NSImage imageNamed:@"pandora"];
+    [icon setSize:size];
+    [NSApp setApplicationIconImage:icon];
   }
 }
 


### PR DESCRIPTION
Fixes the Hermes' dock icon when disabling the "Hide Dock icon and menus" preference. If this preference is disabled the Hermes' dock icon becomes blurry. Diving deeper, it seems that the size of the dock icon was keeping the status bar icon '18' pixel size. This fix sets both the album art and Hermes' icon to both be 1024x1024, the Apple recommended dock icon size. The status bar icon is still set to the '18' size.