### PR TITLE
Prevent duplicate stations and seeds (#320)

### DIFF
--- a/Sources/Controllers/StationController.m
+++ b/Sources/Controllers/StationController.m
@@ -233,6 +233,14 @@
   if (seedsOfKind == nil) {
     seedsOfKind = seeds[seedKind] = [NSMutableArray array];
   }
+  NSString *seedId = seed[@"seedId"];
+  for (NSDictionary *currSeed in seedsOfKind) {
+    NSString *currSeedId = [currSeed objectForKey:@"seedId"];
+    if ([currSeedId isEqualToString:seedId]) {
+      return;
+    }
+  }
+  
   [seedsOfKind addObject:seed];
   seeds[seedKind] = seedsOfKind;
   [seedsCurrent reloadData];


### PR DESCRIPTION
I am not an expert in objective-C by any means so feel free to tear apart but I wanted to get my feet wet. This addresses #320 by simply returning if a duplicate seed is added. I also noticed that this behavior existed for adding duplicate stations so now if you try to add a duplicate station it will just start playing the existing one. 