### PR TITLE
Improve artwork quicklook behavior

### DIFF
--- a/Sources/Controllers/PlaybackController.h
+++ b/Sources/Controllers/PlaybackController.h
@@ -37,6 +37,7 @@
   BOOL scrobbleSent;
   NSString *lastImgSrc;
   NSData *lastImg;
+	BOOL appWasInactive;
 }
 
 @property (readonly) Station *playing;


### PR DESCRIPTION
Don't open artwork quicklook if the app is clicked while it is in the
backgound.  Since 80% of the surface of the main window is the artwork,
clicking on it almost always pops open the artwork quicklook window
which is annoying.